### PR TITLE
Add one-click install for Macbook Pro M4

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,21 @@ To make the Chessnut Pro functional on a Macbook Pro M4, follow these steps:
 4. Run the program using `python main.py`.
 5. If you encounter any issues, refer to the documentation or seek help from the community.
 
+## One-Click Install for Macbook Pro M4
+
+To make the installation process easier for Macbook Pro M4 users, we have provided a one-click install script. Follow these steps:
+
+1. Download the `install_macbook_pro_m4.sh` script from the repository.
+2. Open a terminal and navigate to the directory where the script is located.
+3. Run the script using the following command:
+
+```bash
+./install_macbook_pro_m4.sh
+```
+
+4. The script will install Python 3.8, create a virtual environment, install the required dependencies, and configure the environment for Macbook Pro M4 compatibility.
+5. Once the script completes, you can run the program using `python main.py`.
+
 ## Credits
  rmarabini, for https://github.com/rmarabini/chessnutair \
  Graham O'Neil, for the instruction how the board works (pdf) \

--- a/install_macbook_pro_m4.sh
+++ b/install_macbook_pro_m4.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Install Python 3.8
+echo "Installing Python 3.8..."
+brew install python@3.8
+
+# Create a virtual environment
+echo "Creating a virtual environment..."
+python3.8 -m venv .venv
+
+# Activate the virtual environment
+echo "Activating the virtual environment..."
+source .venv/bin/activate
+
+# Install required dependencies
+echo "Installing required dependencies..."
+pip install -r requirements.txt
+
+# Set macbook_pro_m4_compat flag to true in the configuration file
+echo "Setting macbook_pro_m4_compat flag to true in the configuration file..."
+CONFIG_FILE="~/.config/chessnutair.config"
+if grep -q "macbook_pro_m4_compat" "$CONFIG_FILE"; then
+    sed -i '' 's/macbook_pro_m4_compat = false/macbook_pro_m4_compat = true/' "$CONFIG_FILE"
+else
+    echo "macbook_pro_m4_compat = true" >> "$CONFIG_FILE"
+fi
+
+echo "Installation and configuration complete. You can now run the program using 'python main.py'."


### PR DESCRIPTION
Add a one-click install script for Macbook Pro M4 compatibility.

* **New Script**: Add `install_macbook_pro_m4.sh` to install Python 3.8, create a virtual environment, install dependencies, and configure the environment for Macbook Pro M4 compatibility.
* **Documentation**: Update `README.md` with instructions to run the new install script for Macbook Pro M4.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kitfoxs/ChessnutPy/pull/3?shareId=9f3935ac-7018-46d4-b53c-59a0a5395013).