### PR TITLE
Fix error when launching the game

### DIFF
--- a/main.py
+++ b/main.py
@@ -69,7 +69,7 @@ def get_ip():
         s.connect(('10.254.254.254', 1))
         IP = s.getsockname()[0]
     except Exception:
-        IP = None
+        IP = 'localhost'
     finally:
         s.close()
     return IP


### PR DESCRIPTION
Update `get_ip()` function to return 'localhost' if it fails to determine the local IP address.

* Modify the `get_ip()` function in `main.py` to return 'localhost' instead of `None` when it fails to determine the local IP address.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kitfoxs/ChessnutPy/pull/4?shareId=b671c58e-76f5-4732-944c-d41e1bbdbea6).